### PR TITLE
fix: PIL/Image.py Too many open files

### DIFF
--- a/src/tools.py
+++ b/src/tools.py
@@ -35,7 +35,8 @@ def generate_pdf(book: str, files: list) -> None:
         img: Image.Image = Image.open('{}/{}.jpg'.format(book, pic))
         if img.mode == 'RGBA':
             img = img.convert('RGB')
-        pics.append(img)
+        pics.append(img.copy())
+        img.close()
 
     pdf.save(
         './{}.pdf'.format(book),


### PR DESCRIPTION
合并pdf时 图片太多导致出现"Too many open files" 的错误

参考Pillow([#1237](https://github.com/python-pillow/Pillow/issues/1237))解决方案

复现:

```py
python main.py 俄语八年级全一册 1313001203221 316
```

error

```
OSError: [Errno 24] Too many open files: '俄语八年级全一册/251.jpg'
```